### PR TITLE
Logging fix for Health Check, Timeout bump

### DIFF
--- a/wookiee-core/src/main/scala/com/webtrends/harness/app/HarnessActor.scala
+++ b/wookiee-core/src/main/scala/com/webtrends/harness/app/HarnessActor.scala
@@ -83,7 +83,7 @@ class HarnessActor extends Actor
 
   private val config = context.system.settings.config
 
-  implicit val checkTimeout = getDefaultTimeout(config, HarnessConstants.KeyDefaultTimeout, Timeout(5 seconds))
+  implicit val checkTimeout = getDefaultTimeout(config, HarnessConstants.KeyDefaultTimeout, Timeout(15 seconds))
   val startupTimeout = getDefaultTimeout(config, HarnessConstants.KeyStartupTimeout, Timeout(20 seconds))
   val prepareShutdownTimeout = getDefaultTimeout(config, HarnessConstants.PrepareToShutdownTimeout, Timeout(5 seconds))
 
@@ -276,7 +276,6 @@ class HarnessActor extends Actor
       val p = Promise[Seq[HealthComponent]]()
       future.onComplete({
         case Failure(f) =>
-          log.error("Error fetching health", f)
           p failure f
         case Success(answers) =>
           p success answers.toSeq

--- a/wookiee-core/src/main/scala/com/webtrends/harness/health/ActorHealth.scala
+++ b/wookiee-core/src/main/scala/com/webtrends/harness/health/ActorHealth.scala
@@ -38,13 +38,14 @@ trait ActorHealth {
   import context.dispatcher
 
   implicit val checkTimeout:Timeout =
-    ConfigUtil.getDefaultTimeout(context.system.settings.config, HarnessConstants.KeyDefaultTimeout, Timeout(10 seconds))
+    ConfigUtil.getDefaultTimeout(context.system.settings.config, HarnessConstants.KeyDefaultTimeout, Timeout(15 seconds))
 
   def health:Receive = {
     case CheckHealth =>
       pipe(Try(checkHealth)
         .recover({
         case e: Exception =>
+          _log.error("Error fetching health", e)
           Future.successful(HealthComponent(getClass.getSimpleName, ComponentState.CRITICAL,
             "Exception when trying to check the health: %s".format(e.getMessage)))
       }).get

--- a/wookiee-core/src/main/scala/com/webtrends/harness/health/HealthCheckProvider.scala
+++ b/wookiee-core/src/main/scala/com/webtrends/harness/health/HealthCheckProvider.scala
@@ -27,6 +27,7 @@ import akka.util.Timeout
 import com.webtrends.harness.HarnessConstants
 import com.webtrends.harness.logging.ActorLoggingAdapter
 import com.webtrends.harness.service.messages.CheckHealth
+import com.webtrends.harness.utils.ConfigUtil
 import org.joda.time.DateTime
 
 import scala.collection.mutable
@@ -37,7 +38,8 @@ import scala.util.{Failure, Success}
 trait HealthCheckProvider {
   this: Actor with ActorLoggingAdapter =>
   val upTime = DateTime.now
-  implicit val timeout = Timeout(5 seconds)
+  implicit val timeout =
+    ConfigUtil.getDefaultTimeout(context.system.settings.config, HarnessConstants.KeyDefaultTimeout, Timeout(15 seconds))
 
   val scalaVersion = util.Properties.versionString
   val file = getClass.getProtectionDomain.getCodeSource.getLocation.getFile


### PR DESCRIPTION
* Now log right above any failed health checks and in the culprit itself
* Increase health check default timeout to 15