### PR TITLE
Fix for Broken Pipe error from SimpleHttpServer

### DIFF
--- a/examples/basic-service/pom.xml
+++ b/examples/basic-service/pom.xml
@@ -30,12 +30,12 @@
     <dependencies>
         <dependency>
             <groupId>com.webtrends</groupId>
-            <artifactId>wookiee-core</artifactId>
+            <artifactId>wookiee-core_2.11</artifactId>
             <version>${wookiee.version}</version>
         </dependency>
         <dependency>
             <groupId>com.webtrends</groupId>
-            <artifactId>wookiee-test</artifactId>
+            <artifactId>wookiee-test_2.11</artifactId>
             <version>${wookiee.version}</version>
             <scope>test</scope>
         </dependency>

--- a/wookiee-core/src/main/scala/com/webtrends/harness/http/SimpleHttpServer.scala
+++ b/wookiee-core/src/main/scala/com/webtrends/harness/http/SimpleHttpServer.scala
@@ -69,7 +69,11 @@ class SimpleHttpServer(port:Int=8008) extends HActor with ComponentHelper {
     httpExchange.getResponseHeaders.set("Content-Type", contentType)
     httpExchange.sendResponseHeaders(responseStatus, response.length())
     if (response.length > 0) {
-      httpExchange.getResponseBody.write(response.getBytes)
+      try {
+        httpExchange.getResponseBody.write(response.getBytes)
+      } catch {
+        case _: IOException => log.debug("Broken Pipe, client-side must have severed connection...")
+      }
     }
     httpExchange.close()
   }


### PR DESCRIPTION
* Was caused by failing to catch an IOException