### PR TITLE
Fixed typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ Each component loaded in Wookiee should provide a default configuration that wil
 uses Typesafe Config to load configurations at runtime in layers.  A component's default configuration should be given the lowest
 priority, the reference conf, following the layered priority schema set by Typesafe Config.  This can be problematic at times, as third party libs
 and components with equally prioritized, overlapping configurations are combined in the application.  To ensure component 
-configurations take precedence, place components jars at the begining of the classpath.  One approach is to separate components
+configurations take precedence, place components jars at the beginning of the classpath.  One approach is to separate components
 from third party libs in the distribution.
 
 Maven dist.xml


### PR DESCRIPTION
Changed mispelling "begining" to the correct spelling "beginning".